### PR TITLE
Update software configuration to be able to run on latest g5k nodes

### DIFF
--- a/common.py
+++ b/common.py
@@ -2,8 +2,8 @@ import subprocess, pipes
 
 packages = {
     "atlas": {
-        "version": "3.10.0",
-        "archive": "atlas3.10.0.tar.bz2",
+        "version": "3.10.3",
+        "archive": "atlas3.10.3.tar.bz2",
         "extract_dir": "ATLAS",
         "deps": []
         },

--- a/node_prepare_atlas
+++ b/node_prepare_atlas
@@ -48,7 +48,7 @@ mkdir build
 cd build
 myecho "configure atlas"
 POINTER_BITWIDTH=`getconf LONG_BIT`
-../configure --prefix=$WORKDIR/atlas-install --nof77 -t 0 -b "$POINTER_BITWIDTH"
+../configure --prefix=$WORKDIR/atlas-install --nof77 -t 0 -b "$POINTER_BITWIDTH" --cripple-atlas-performance
 myecho "make atlas"
 make
 

--- a/node_prepare_openmpi
+++ b/node_prepare_openmpi
@@ -33,7 +33,7 @@ tar xjf "$SOURCEARCHIVE"
 
 myecho "configure openmpi"
 cd "$WORKDIR/$EXTRACTDIR"
-./configure --prefix=$WORKDIR/openmpi-install --enable-branch-probabilities --with-memory-manager=none
+./configure --prefix=$WORKDIR/openmpi-install --enable-branch-probabilities --with-memory-manager=none --disable-vt
 myecho "make openmpi"
 make
 


### PR DESCRIPTION
Disabling frequency detection is needed for ATLAS as it does not detect/accept
the frequency policy used on latest Intel CPU (though it is the "performance"
governor). The option is only available in latest ATLAS version.

Disabling vt on openmpi should be harmless.